### PR TITLE
Fix larva spawn timing

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['10', '12', '14', '16']
+        node: ['12', '14', '16']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ With the arrow keys (left and right) you can navigate through the build order. H
 
 ## Requirements
 
-[Node 10 or newer](https://nodejs.org/en/download/) is required to create this static website.
+[Node 12 or newer](https://nodejs.org/en/download/) is required to create this static website.
 
 [Python 3.7 or newer](https://www.python.org/downloads/) is required to run pre-commit hooks and e2e tests.
 

--- a/src/game_logic/unit.ts
+++ b/src/game_logic/unit.ts
@@ -47,7 +47,7 @@ class Unit {
         this.hasChronoUntilFrame = -1
         // Zerg townhalls
         this.hasInjectUntilFrame = -1
-        this.nextLarvaSpawn = -1
+        this.nextLarvaSpawn = 10.71428571 * 22.4
         this.larvaCount = 0
         this.backgroundTask = []
         // Terran depot
@@ -148,12 +148,12 @@ class Unit {
         if (["Hatchery", "Lair", "Hive"].includes(this.name)) {
             // If at max larva, dont generate new one until 11 secs elapsed
             if (this.larvaCount >= 3) {
-                this.nextLarvaSpawn = gamelogic.frame + 11 * 22.4
+                this.nextLarvaSpawn = gamelogic.frame + 10.71428571 * 22.4
             }
 
             if (this.nextLarvaSpawn < gamelogic.frame) {
                 this.larvaCount += 1
-                this.nextLarvaSpawn = gamelogic.frame + 11 * 22.4
+                this.nextLarvaSpawn = gamelogic.frame + 10.71428571 * 22.4
             }
 
             // If has inject: spawn larva when frame has been reached

--- a/src/game_logic/unit.ts
+++ b/src/game_logic/unit.ts
@@ -151,9 +151,9 @@ class Unit {
                 this.nextLarvaSpawn = gamelogic.frame + 10.71428571 * 22.4
             }
 
-            if (this.nextLarvaSpawn < gamelogic.frame) {
+            if (this.nextLarvaSpawn <= gamelogic.frame) {
                 this.larvaCount += 1
-                this.nextLarvaSpawn = gamelogic.frame + 10.71428571 * 22.4
+                this.nextLarvaSpawn = this.nextLarvaSpawn + 10.71428571 * 22.4
             }
 
             // If has inject: spawn larva when frame has been reached

--- a/src/game_logic/unit.ts
+++ b/src/game_logic/unit.ts
@@ -47,6 +47,9 @@ class Unit {
         this.hasChronoUntilFrame = -1
         // Zerg townhalls
         this.hasInjectUntilFrame = -1
+        // Larva naturally spawns every 15 seconds at normal speed
+        // Faster speed is a 1.4 multiplier, so the spawn timer at faster is
+        // 15 / 1.4 = 10.71428571...
         this.nextLarvaSpawn = 10.71428571 * 22.4
         this.larvaCount = 0
         this.backgroundTask = []

--- a/src/game_logic/unit.ts
+++ b/src/game_logic/unit.ts
@@ -148,7 +148,7 @@ class Unit {
         if (["Hatchery", "Lair", "Hive"].includes(this.name)) {
             // If at max larva, dont generate new one until 11 secs elapsed
             if (this.larvaCount >= 3) {
-                this.nextLarvaSpawn = gamelogic.frame + 10.71428571 * 22.4
+                this.nextLarvaSpawn += 1
             }
 
             if (this.nextLarvaSpawn <= gamelogic.frame) {


### PR DESCRIPTION
Natural larva spawns weren't lining up correctly with the actual game.  The main issues were
1) Incorrect constant for how long it takes for a larva to spawn.
2) Rounding errors because the floating point number of frames out to wait is being recalculated off of the current integer frame each time.
3) The larva spawn timer was being reset instead of paused when larva capped.
After these changes, larva spawns line up with the game.