### PR TITLE
Init larva timer in game tick

### DIFF
--- a/src/game_logic/unit.ts
+++ b/src/game_logic/unit.ts
@@ -47,10 +47,7 @@ class Unit {
         this.hasChronoUntilFrame = -1
         // Zerg townhalls
         this.hasInjectUntilFrame = -1
-        // Larva naturally spawns every 15 seconds at normal speed
-        // Faster speed is a 1.4 multiplier, so the spawn timer at faster is
-        // 15 / 1.4 = 10.71428571...
-        this.nextLarvaSpawn = 10.71428571 * 22.4
+        this.nextLarvaSpawn = -1
         this.larvaCount = 0
         this.backgroundTask = []
         // Terran depot
@@ -149,14 +146,27 @@ class Unit {
 
         // If is zerg townhall: generate new larva
         if (["Hatchery", "Lair", "Hive"].includes(this.name)) {
-            // If at max larva, dont generate new one until 11 secs elapsed
+            // Larva naturally spawns every 15 seconds at normal speed
+            // Faster speed is a 1.4 multiplier, so the spawn timer at faster is
+            // 15 / 1.4 = 10.71428571...
+            const larvaSpawnTime = 10.71428571
+
+            //init larva time for new hatch
+            if (this.nextLarvaSpawn === -1) {
+                this.nextLarvaSpawn = gamelogic.frame + (larvaSpawnTime * 22.4)
+                if (this.larvaCount == 0) {
+                    this.larvaCount = 1
+                }
+            }
+
+            // If at max larva, pause larva timer
             if (this.larvaCount >= 3) {
                 this.nextLarvaSpawn += 1
             }
 
             if (this.nextLarvaSpawn <= gamelogic.frame) {
                 this.larvaCount += 1
-                this.nextLarvaSpawn = this.nextLarvaSpawn + 10.71428571 * 22.4
+                this.nextLarvaSpawn = this.nextLarvaSpawn + (larvaSpawnTime * 22.4)
             }
 
             // If has inject: spawn larva when frame has been reached


### PR DESCRIPTION
Initializing the larva timer in the constructor bases it on game frame
0, which causes a bug for every hatch after the first.
We can check if it is uninitialized in the game tick and set it based on
the current frame.
We also need to give a single larva if there aren't any because hatches
spawn with one larva (except for the first which spawns with 3).
Initializing the larva count in the constructor also causes a weird bug
that I couldn't figure out, so I'm also initializing it in the game
tick.

Signed-off-by: dusoleil <howcansocksbereal@gmail.com>