### PR TITLE
Update for patch 5.0.16

### DIFF
--- a/src/constants/data.json
+++ b/src/constants/data.json
@@ -87,7 +87,6 @@
       "CastOutroTime": 0.5,
       "CmdButtonArray": {
         "DefaultButtonFace": "AmorphousArmorcloud",
-        "Requirements": "UseAmorphousArmorcloud",
         "index": "Execute"
       },
       "Cost": {
@@ -104,7 +103,7 @@
         "AllowMovement": 1,
         "NoDeceleration": 1
       },
-      "Range": 9,
+      "Range": 12,
       "id": "AmorphousArmorcloud",
       "name": "AmorphousArmorcloud"
     },
@@ -139,6 +138,19 @@
       "morphsto": "Archon",
       "name": "ArchonWarp",
       "race": "Protoss"
+    },
+    "ArmSiloWithNuke": {
+      "InfoArray": {
+        "Charge": {
+          "Link": "Abil/##id##"
+        },
+        "Cooldown": {
+          "Link": "Abil/##id##"
+        },
+        "index": "Ammo1"
+      },
+      "id": 729,
+      "name": "ArmSiloWithNuke"
     },
     "ArmoryResearch": {
       "EditorCategories": "Race:Terran,AbilityorEffectType:Structures",
@@ -1162,32 +1174,19 @@
       "Flags": {
         "IgnoreFacing": 1,
         "IgnoreFood": 1,
-        "IgnorePlacement": 0,
+        "IgnorePlacement": 1,
         "IgnoreUnitCost": 1,
-        "Interruptible": 1
+        "Interruptible": 1,
+        "Transient": 1
       },
       "InfoArray": {
         "RandomDelayMax": "0.3703",
-        "SectionArray": [
-          {
-            "DurationArray": {
-              "Delay": 0.5
-            },
-            "index": "Collide"
+        "SectionArray": {
+          "EffectArray": {
+            "Start": "InfestorBurrowDownTransient"
           },
-          {
-            "DurationArray": {
-              "Delay": 0.5
-            },
-            "index": "Stats"
-          },
-          {
-            "DurationArray": {
-              "Duration": 0.5
-            },
-            "index": "Actor"
-          }
-        ],
+          "index": "Actor"
+        },
         "Unit": "InfestorBurrowed"
       },
       "id": 1445,
@@ -1370,32 +1369,41 @@
         },
         "index": "Execute"
       },
+      "Cost": {
+        "Cooldown": {
+          "TimeUse": "1.4"
+        }
+      },
       "EditorCategories": "Race:Zerg,AbilityorEffectType:MorphsandBurrows",
       "Flags": {
         "IgnoreFacing": 1,
         "IgnoreFood": 1,
-        "IgnorePlacement": 0,
+        "IgnorePlacement": 1,
         "IgnoreUnitCost": 1,
-        "Interruptible": 1
+        "Interruptible": 1,
+        "Transient": 1
       },
       "InfoArray": {
         "RandomDelayMax": "0.1",
         "SectionArray": [
           {
             "DurationArray": {
-              "Delay": 0.5556
+              "Delay": 0.1
             },
             "index": "Collide"
           },
           {
             "DurationArray": {
-              "Delay": 0.5556
+              "Delay": 0.31
             },
             "index": "Stats"
           },
           {
             "DurationArray": {
-              "Duration": 0.5556
+              "Duration": 0.31
+            },
+            "EffectArray": {
+              "Start": "RoachBurrowDownTransient"
             },
             "index": "Actor"
           }
@@ -1577,7 +1585,7 @@
       ],
       "Cost": {
         "Vital": {
-          "Energy": 50
+          "Energy": 75
         }
       },
       "EditorCategories": "Race:Terran,AbilityorEffectType:Units",
@@ -1852,12 +1860,9 @@
         },
         {
           "Button": {
-            "DefaultButtonFace": "ResearchWarpGate",
             "Flags": {
-              "ShowInGlossary": 1
-            },
-            "Requirements": "LearnWarpGate",
-            "State": "Restricted"
+              "ShowInGlossary": 0
+            }
           },
           "Resource": {
             "Minerals": 50,
@@ -1975,11 +1980,10 @@
       },
       "Cost": {
         "Charge": {
-          "Link": "Abil/BatteryOvercharge"
-        },
-        "Cooldown": {
+          "CountMax": 1,
+          "CountUse": 1,
           "Location": "Player",
-          "TimeUse": "63"
+          "TimeUse": 63
         },
         "Vital": {
           "Energy": 50
@@ -2916,39 +2920,19 @@
       "InfoArray": [
         {
           "Button": {
-            "DefaultButtonFace": "DarkTemplar",
-            "Requirements": "HaveDarkShrine",
-            "State": "Restricted"
+            "Flags": {
+              "ToSelection": 1
+            }
           },
-          "Time": "55",
-          "Unit": "DarkTemplar",
-          "index": "Train5"
-        },
-        {
-          "Button": {
-            "DefaultButtonFace": "HighTemplar",
-            "Requirements": "HaveTemplarArchives",
-            "State": "Restricted"
-          },
-          "Time": "55",
-          "Unit": "HighTemplar",
-          "index": "Train4"
-        },
-        {
-          "Button": {
-            "DefaultButtonFace": "Sentry",
-            "Requirements": "HaveCyberneticsCore",
-            "State": "Restricted"
-          },
-          "Time": "32",
+          "Time": "32.66",
           "Unit": "Sentry",
           "index": "Train6"
         },
         {
           "Button": {
-            "DefaultButtonFace": "Stalker",
-            "Requirements": "HaveCyberneticsCore",
-            "State": "Restricted"
+            "Flags": {
+              "ToSelection": 1
+            }
           },
           "Time": "38",
           "Unit": "Stalker",
@@ -2956,9 +2940,19 @@
         },
         {
           "Button": {
-            "DefaultButtonFace": "WarpInAdept",
-            "Requirements": "HaveCyberneticsCore",
-            "State": "Restricted"
+            "Flags": {
+              "ToSelection": 1
+            }
+          },
+          "Time": "38",
+          "Unit": "Zealot",
+          "index": "Train1"
+        },
+        {
+          "Button": {
+            "Flags": {
+              "ToSelection": 1
+            }
           },
           "Time": "42",
           "Unit": "Adept",
@@ -2966,16 +2960,45 @@
         },
         {
           "Button": {
-            "DefaultButtonFace": "Zealot",
-            "State": "Restricted"
+            "Flags": {
+              "ToSelection": 1
+            }
           },
-          "Time": "38",
-          "Unit": "Zealot",
-          "index": "Train1"
+          "Time": "60.66",
+          "Unit": "DarkTemplar",
+          "index": "Train5"
+        },
+        {
+          "Button": {
+            "Flags": {
+              "ToSelection": 1
+            }
+          },
+          "Time": "60.66",
+          "Unit": "HighTemplar",
+          "index": "Train4"
         }
       ],
       "id": 945,
       "name": "GatewayTrain"
+    },
+    "GenerateCreep": {
+      "CmdButtonArray": [
+        {
+          "Flags": {
+            "ToSelection": 1
+          },
+          "index": "Off"
+        },
+        {
+          "Flags": {
+            "ToSelection": 1
+          },
+          "index": "On"
+        }
+      ],
+      "id": 1693,
+      "name": "GenerateCreep"
     },
     "GhostAcademyResearch": {
       "EditorCategories": "Race:Terran,AbilityorEffectType:Structures",
@@ -3053,6 +3076,7 @@
     },
     "GravitonBeam": {
       "AbilSetId": "Graviton",
+      "ArcSlop": 360,
       "CancelableArray": {
         "Channel": 1
       },
@@ -3134,7 +3158,8 @@
         "0": "HallucinationCreateAdept"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 2392,
       "name": "HallucinationAdept"
@@ -3155,7 +3180,8 @@
         "0": "HallucinationCreateArchon"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 147,
       "name": "HallucinationArchon"
@@ -3176,7 +3202,8 @@
         "0": "HallucinationCreateColossus"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 149,
       "name": "HallucinationColossus"
@@ -3196,7 +3223,8 @@
         "0": "HallucinationCreateDisruptor"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 2390,
       "name": "HallucinationDisruptor"
@@ -3217,7 +3245,8 @@
         "0": "HallucinationCreateHighTemplar"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 151,
       "name": "HallucinationHighTemplar"
@@ -3238,7 +3267,8 @@
         "0": "HallucinationCreateImmortal"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 153,
       "name": "HallucinationImmortal"
@@ -3259,7 +3289,8 @@
         "0": "HallucinationCreateOracle"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 2115,
       "name": "HallucinationOracle"
@@ -3280,7 +3311,8 @@
         "0": "HallucinationCreatePhoenix"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 155,
       "name": "HallucinationPhoenix"
@@ -3301,7 +3333,8 @@
         "0": "HallucinationCreateProbe"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 157,
       "name": "HallucinationProbe"
@@ -3322,7 +3355,8 @@
         "0": "HallucinationCreateStalker"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 159,
       "name": "HallucinationStalker"
@@ -3343,7 +3377,8 @@
         "0": "HallucinationCreateVoidRay"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 161,
       "name": "HallucinationVoidRay"
@@ -3364,7 +3399,8 @@
         "0": "HallucinationCreateWarpPrism"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 163,
       "name": "HallucinationWarpPrism"
@@ -3385,7 +3421,8 @@
         "0": "HallucinationCreateZealot"
       },
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "TransientPreferred": 1
       },
       "id": 165,
       "name": "HallucinationZealot"
@@ -3692,7 +3729,9 @@
           "TimeUse": "20"
         }
       },
+      "CursorEffect": "KD8SearchArea",
       "EditorCategories": "Race:Terran,AbilityorEffectType:Units",
+      "Placeholder": "KD8Charge",
       "Range": 5,
       "TargetFilters": "Ground,Visible;-",
       "id": 2589,
@@ -3771,7 +3810,7 @@
       "Activity": "UI/Morphing",
       "EditorCategories": "Race:Zerg,AbilityorEffectType:MorphsandBurrows",
       "Flags": {
-        "DisableCollision": 1,
+        "DisableCollision": 0,
         "KillOnCancel": 1,
         "KillOnFinish": 1,
         "Select": 1,
@@ -4174,35 +4213,13 @@
     },
     "MedivacTransport": {
       "AbilSetId": "ULdM",
-      "CmdButtonArray": [
-        {
-          "DefaultButtonFace": "MedivacLoad",
-          "index": "Load"
+      "CmdButtonArray": {
+        "DefaultButtonFace": "LoadNearbyMedivac",
+        "Flags": {
+          "Hidden": 0
         },
-        {
-          "DefaultButtonFace": "MedivacUnloadAll",
-          "index": "UnloadAt"
-        },
-        {
-          "Flags": {
-            "Hidden": 1,
-            "ToSelection": 1
-          },
-          "index": "UnloadAll"
-        },
-        {
-          "Flags": {
-            "Hidden": 1
-          },
-          "index": "LoadAll"
-        },
-        {
-          "Flags": {
-            "Hidden": 1
-          },
-          "index": "UnloadUnit"
-        }
-      ],
+        "index": "LoadAll"
+      },
       "EditorCategories": "Race:Terran,AbilityorEffectType:Units",
       "Flags": {
         "CargoDeath": 1
@@ -4210,6 +4227,7 @@
       "LoadValidatorArray": "NotWidowMineTarget",
       "MaxCargoCount": 8,
       "MaxCargoSize": 8,
+      "SearchRadius": 4,
       "TargetFilters": "Visible;Self,Ally,Neutral,Enemy,Buried,UnderConstruction,Dead,Hidden",
       "TotalCargoSpace": 8,
       "UnloadCargoEffect": "PurificationNovaTargettedCasterRB",
@@ -4264,16 +4282,14 @@
     },
     "MorphBackToGateway": {
       "Alert": "TransformationComplete",
-      "CmdButtonArray": [
-        {
-          "DefaultButtonFace": "Cancel",
-          "index": "Cancel"
+      "BehaviorOff": "WarpgateDemorphing",
+      "BehaviorOn": "WarpgateDemorphing",
+      "CmdButtonArray": {
+        "Flags": {
+          "ToSelection": 1
         },
-        {
-          "DefaultButtonFace": "MorphBackToGateway",
-          "index": "Execute"
-        }
-      ],
+        "index": "Execute"
+      },
       "Cost": {
         "Cooldown": {
           "Link": "WarpGateTrain",
@@ -4286,19 +4302,116 @@
         "Birth": 1,
         "DisableAbils": 1,
         "FastBuild": 1,
+        "Interruptible": 1,
         "ShowProgress": 1
       },
       "InfoArray": {
-        "SectionArray": {
-          "EffectArray": {
-            "Finish": "UpgradeToWarpGateAutoCastDisabler"
+        "SectionArray": [
+          {
+            "DurationArray": {
+              "Delay": 7
+            },
+            "EffectArray": {
+              "Finish": "UpgradeToWarpGateAutoCastDisabler"
+            },
+            "index": "Abils"
           },
-          "index": "Abils"
-        },
+          {
+            "DurationArray": {
+              "Delay": 7
+            },
+            "index": "Stats"
+          },
+          {
+            "DurationArray": {
+              "Duration": 7
+            },
+            "index": "Actor"
+          }
+        ],
         "Unit": "Gateway"
       },
       "id": 1521,
       "name": "MorphBackToGateway"
+    },
+    "MorphBuildingGatewayWarpGateFree": {
+      "Activity": "UI/Transforming",
+      "Alert": "TransformationComplete",
+      "AutoCastCountMax": 500,
+      "AutoCastRange": 5,
+      "AutoCastValidatorArray": "NotHaveUpgradeToWarpGateAutoCastDisabler",
+      "BehaviorOff": "MorphingintoWarpGate",
+      "BehaviorOn": "MorphingintoWarpGate",
+      "CmdButtonArray": [
+        {
+          "DefaultButtonFace": "Cancel",
+          "index": "Cancel"
+        },
+        {
+          "DefaultButtonFace": "UpgradeToWarpGate",
+          "Flags": {
+            "ShowInGlossary": 0,
+            "ToSelection": 1
+          },
+          "Requirements": "UseWarpGateHideFree",
+          "State": "Restricted",
+          "index": "Execute"
+        }
+      ],
+      "Cost": {
+        "Charge": {
+          "CountMax": 1,
+          "CountStart": 1,
+          "CountUse": 1,
+          "TimeUse": 10
+        }
+      },
+      "EditorCategories": "Race:Protoss,AbilityorEffectType:MorphsandBurrows",
+      "Flags": {
+        "BestUnit": 1,
+        "Birth": 1,
+        "DisableAbils": 1,
+        "FastBuild": 1,
+        "Interruptible": 1,
+        "Produce": 1,
+        "ShowProgress": 1
+      },
+      "InfoArray": {
+        "SectionArray": [
+          {
+            "DurationArray": {
+              "Delay": 10
+            },
+            "EffectArray": {
+              "Finish": "HasMorphedBefore"
+            },
+            "index": "Abils"
+          },
+          {
+            "DurationArray": {
+              "Delay": 10
+            },
+            "index": "Stats"
+          },
+          {
+            "DurationArray": {
+              "Duration": 10
+            },
+            "index": "Actor"
+          }
+        ],
+        "Unit": "WarpGate"
+      },
+      "RefundFraction": {
+        "Resource": {
+          "Custom": -1,
+          "Minerals": -1,
+          "Terrazine": -1,
+          "Vespene": -1
+        }
+      },
+      "id": "MorphBuildingGatewayWarpGateFree",
+      "name": "MorphBuildingGatewayWarpGateFree"
     },
     "MorphToBaneling": {
       "Alert": "MorphComplete_Zerg",
@@ -5656,9 +5769,12 @@
         "index": "Execute"
       },
       "Cost": {
-        "Cooldown": {
+        "Charge": {
+          "CountMax": 1,
+          "CountStart": 1,
+          "CountUse": 1,
           "Location": "Player",
-          "TimeUse": "182"
+          "TimeUse": 182
         },
         "Vital": {
           "Energy": 50
@@ -5702,6 +5818,7 @@
         "Unit": "Mothership",
         "index": "Train1"
       },
+      "Offset": "0,0",
       "id": 139,
       "name": "NexusTrainMothership"
     },
@@ -5882,13 +5999,19 @@
     "OracleStasisTrapBuild": {
       "EditorCategories": "Race:Protoss,AbilityorEffectType:Units",
       "EffectArray": {
-        "Cancel": "OracleStasisTrapBuildBeamOff",
-        "Finish": "OracleStasisTrapBuildBeamOff",
-        "Start": "OracleStasisTrapBuildBeamOn"
+        "Cancel": "OracleFacePersistentDestroy",
+        "Finish": "OracleFacePersistentDestroy",
+        "Start": "StasisWardPlaceSet"
       },
-      "FlagArray": {
-        "RequireFacing": 1
-      },
+      "FidgetDelayMax": 0.0625,
+      "FlagArray": [
+        {
+          "RequireFacing": 0
+        },
+        {
+          "RequireFacing": 1
+        }
+      ],
       "InfoArray": {
         "Button": {
           "DefaultButtonFace": "OracleBuildStasisTrap",
@@ -5896,7 +6019,7 @@
             "ShowInGlossary": 1
           }
         },
-        "Time": "5",
+        "Time": "5.6",
         "Unit": "OracleStasisTrap",
         "Vital": {
           "Energy": 50
@@ -5906,46 +6029,6 @@
       "Range": 5,
       "id": 2535,
       "name": "OracleStasisTrapBuild"
-    },
-    "OracleWeapon": {
-      "BehaviorArray": "OracleWeapon",
-      "CmdButtonArray": [
-        {
-          "DefaultButtonFace": "OracleWeaponOff",
-          "Flags": {
-            "ToSelection": 1
-          },
-          "index": "Off"
-        },
-        {
-          "DefaultButtonFace": "OracleWeaponOn",
-          "Flags": {
-            "ToSelection": 1
-          },
-          "index": "On"
-        }
-      ],
-      "Cost": {
-        "Charge": {
-          "Link": "Abil/OracleWeapon"
-        },
-        "Cooldown": {
-          "TimeUse": "4"
-        },
-        "Vital": {
-          "Energy": 25
-        },
-        "index": "0"
-      },
-      "EditorCategories": "Race:Terran,AbilityorEffectType:Units",
-      "Flags": {
-        "Toggle": 1,
-        "Transient": 1
-      },
-      "Name": "Abil/Name/OracleWeapon",
-      "id": 2376,
-      "name": "OracleWeapon",
-      "parent": "GhostCloak"
     },
     "OrbitalCommandLand": {
       "InfoArray": {
@@ -5971,10 +6054,20 @@
     },
     "OverlordTransport": {
       "AbilSetId": "ULdM",
-      "CmdButtonArray": {
-        "Requirements": "UseSingleOverlordTransport",
-        "index": "Load"
-      },
+      "CmdButtonArray": [
+        {
+          "DefaultButtonFace": "LoadNearbyOverlord",
+          "Flags": {
+            "Hidden": 0
+          },
+          "Requirements": "UseSingleOverlordTransport",
+          "index": "LoadAll"
+        },
+        {
+          "Requirements": "UseSingleOverlordTransport",
+          "index": "Load"
+        }
+      ],
       "EditorCategories": "Race:Zerg,AbilityorEffectType:Units",
       "Flags": {
         "CargoDeath": 1
@@ -5983,6 +6076,7 @@
       "LoadValidatorArray": "NotWidowMineTarget",
       "MaxCargoCount": 8,
       "MaxCargoSize": 8,
+      "SearchRadius": 4,
       "TargetFilters": "Visible;Ally,Neutral,Enemy,Buried,UnderConstruction,Dead,Hidden",
       "TotalCargoSpace": 8,
       "UnloadCargoEffect": "PurificationNovaTargettedCasterRB",
@@ -6077,7 +6171,8 @@
       "EditorCategories": "Race:Protoss,AbilityorEffectType:MorphsandBurrows",
       "Flags": {
         "BestUnit": 1,
-        "IgnoreFacing": 1
+        "IgnoreFacing": 1,
+        "WaitUntilStopped": 0
       },
       "InfoArray": {
         "SectionArray": [
@@ -7195,7 +7290,8 @@
       },
       "EditorCategories": "Race:Zerg,AbilityorEffectType:Units",
       "Flags": {
-        "BestUnit": 1
+        "BestUnit": 1,
+        "Transient": 1
       },
       "ProducedUnitArray": "Changeling",
       "id": 182,
@@ -7203,7 +7299,9 @@
     },
     "SpawnLarva": {
       "AINotifyEffect": "SpawnMutantLarva",
-      "CastOutroTime": 2.3,
+      "CastOutroTime": {
+        "0": 0
+      },
       "CmdButtonArray": {
         "DefaultButtonFace": "MorphMorphalisk",
         "index": "Execute"
@@ -7222,6 +7320,9 @@
       "EditorCategories": "Race:Zerg,AbilityorEffectType:Units",
       "Effect": {
         "0": "SpawnLarvaSet"
+      },
+      "Flags": {
+        "ReExecutable": 1
       },
       "Marker": {
         "Link": "Abil/SpawnMutantLarva"
@@ -7261,6 +7362,9 @@
         "Transient": 1
       },
       "Range": 500,
+      "SharedFlags": {
+        "RegisterCooldownEvent": 1
+      },
       "id": 2705,
       "name": "SpawnLocustsTargeted"
     },
@@ -8277,6 +8381,11 @@
     "TerranBuild": {
       "ConstructionMover": "Construction",
       "EditorCategories": "Race:Terran,AbilityorEffectType:Units",
+      "EffectArray": {
+        "Cancel": "SCVCancelBuildingSet",
+        "Finish": "SCVFinishBuildingSet",
+        "Start": "SCVStartBuildingSet"
+      },
       "FidgetDelayMax": 8.5,
       "FidgetDelayMin": 6.5,
       "FlagArray": {
@@ -9137,51 +9246,47 @@
       "AutoCastCountMax": 500,
       "AutoCastRange": 5,
       "AutoCastValidatorArray": "NotHaveUpgradeToWarpGateAutoCastDisabler",
-      "CmdButtonArray": [
-        {
-          "DefaultButtonFace": "Cancel",
-          "index": "Cancel"
+      "BehaviorOff": "MorphingintoWarpGate",
+      "BehaviorOn": "MorphingintoWarpGate",
+      "CmdButtonArray": {
+        "Flags": {
+          "ToSelection": 1
         },
-        {
-          "DefaultButtonFace": "UpgradeToWarpGate",
-          "Requirements": "UseWarpGate",
-          "State": "Restricted",
-          "index": "Execute"
+        "Requirements": "UseWarpgateNotMorphedBefore",
+        "index": "Execute"
+      },
+      "Cost": {
+        "Resource": {
+          "Minerals": 25,
+          "Vespene": 25
         }
-      ],
+      },
       "EditorCategories": "Race:Protoss,AbilityorEffectType:MorphsandBurrows",
       "Flags": {
-        "AutoCast": 1,
-        "AutoCastOn": 1,
         "BestUnit": 1,
         "Birth": 1,
         "DisableAbils": 1,
         "FastBuild": 1,
+        "Interruptible": 1,
         "Produce": 1,
         "ShowProgress": 1
       },
       "InfoArray": {
-        "SectionArray": [
-          {
-            "DurationArray": {
-              "Delay": 10
-            },
-            "index": "Abils"
+        "SectionArray": {
+          "EffectArray": {
+            "Finish": "HasMorphedBefore"
           },
-          {
-            "DurationArray": {
-              "Delay": 10
-            },
-            "index": "Stats"
-          },
-          {
-            "DurationArray": {
-              "Duration": 10
-            },
-            "index": "Actor"
-          }
-        ],
+          "index": "Abils"
+        },
         "Unit": "WarpGate"
+      },
+      "RefundFraction": {
+        "Resource": {
+          "Custom": -1,
+          "Minerals": -1,
+          "Terrazine": -1,
+          "Vespene": -1
+        }
       },
       "id": 1519,
       "morphsto": "WarpGate",
@@ -9278,26 +9383,6 @@
       "id": 2157,
       "name": "VoidSiphon"
     },
-    "VolatileBurstBuilding": {
-      "BehaviorArray": "VolatileBurstBuilding",
-      "CmdButtonArray": [
-        {
-          "DefaultButtonFace": "DisableBuildingAttack",
-          "index": "Off"
-        },
-        {
-          "DefaultButtonFace": "EnableBuildingAttack",
-          "index": "On"
-        }
-      ],
-      "EditorCategories": "Race:Zerg,AbilityorEffectType:Units",
-      "Flags": {
-        "Toggle": 1,
-        "Transient": 1
-      },
-      "id": 2082,
-      "name": "VolatileBurstBuilding"
-    },
     "Vortex": {
       "Arc": 360,
       "AutoCastFilters": "Visible;Self,Player,Ally",
@@ -9337,141 +9422,100 @@
       "InfoArray": [
         {
           "Button": {
-            "DefaultButtonFace": "DarkTemplar",
-            "Requirements": "HaveDarkShrine",
-            "State": "Restricted"
+            "Flags": {
+              "ToSelection": 1
+            }
           },
           "Charge": {
-            "CountMax": 1,
-            "CountStart": 1,
-            "CountUse": 1,
-            "Flags": {
-              "EnableChargeTimeQueuing": 1
-            },
-            "Link": "WarpGateTrain",
-            "TimeUse": 45
+            "TimeStart": "32.8",
+            "TimeUse": "30.8"
           },
           "Cooldown": {
             "TimeUse": "0"
           },
-          "Time": "16",
-          "Unit": "DarkTemplar",
-          "index": "Train5"
+          "Time": "5.6",
+          "Unit": "Zealot",
+          "index": "Train1"
         },
         {
           "Button": {
-            "DefaultButtonFace": "HighTemplar",
-            "Requirements": "HaveTemplarArchives",
-            "State": "Restricted"
+            "Flags": {
+              "ToSelection": 1
+            }
           },
           "Charge": {
-            "CountMax": 1,
-            "CountStart": 1,
-            "CountUse": 1,
-            "Flags": {
-              "EnableChargeTimeQueuing": 1
-            },
-            "Link": "WarpGateTrain",
-            "TimeUse": 45
-          },
-          "Cooldown": {
-            "TimeUse": "0"
-          },
-          "Time": "16",
-          "Unit": "HighTemplar",
-          "index": "Train4"
-        },
-        {
-          "Button": {
-            "DefaultButtonFace": "Sentry",
-            "Requirements": "HaveCyberneticsCore",
-            "State": "Restricted"
-          },
-          "Charge": {
-            "CountMax": 1,
-            "CountStart": 1,
-            "CountUse": 1,
-            "Flags": {
-              "EnableChargeTimeQueuing": 1
-            },
-            "Link": "WarpGateTrain",
-            "TimeUse": 32
-          },
-          "Cooldown": {
-            "TimeUse": "0"
-          },
-          "Time": "16",
-          "Unit": "Sentry",
-          "index": "Train6"
-        },
-        {
-          "Button": {
-            "DefaultButtonFace": "Stalker",
-            "Requirements": "HaveCyberneticsCore",
-            "State": "Restricted"
-          },
-          "Charge": {
-            "CountMax": 1,
-            "CountStart": 1,
-            "CountUse": 1,
-            "Flags": {
-              "EnableChargeTimeQueuing": 1
-            },
-            "Link": "WarpGateTrain",
-            "TimeUse": 32
-          },
-          "Cooldown": {
-            "TimeUse": "0"
-          },
-          "Time": "16",
-          "Unit": "Stalker",
-          "index": "Train2"
-        },
-        {
-          "Button": {
-            "DefaultButtonFace": "WarpInAdept",
-            "Requirements": "HaveCyberneticsCore",
-            "State": "Restricted"
-          },
-          "Charge": {
-            "CountMax": 1,
-            "CountStart": 1,
-            "CountUse": 1,
-            "Flags": {
-              "EnableChargeTimeQueuing": 1
-            },
-            "Link": "WarpGateTrain",
-            "TimeUse": 28
+            "TimeUse": "30.8"
           },
           "Cooldown": {
             "Link": "WarpGateTrain"
           },
-          "Time": "16",
+          "Time": "5.6",
           "Unit": "Adept",
           "index": "Train7"
         },
         {
           "Button": {
-            "DefaultButtonFace": "Zealot",
-            "State": "Restricted"
+            "Flags": {
+              "ToSelection": 1
+            }
           },
           "Charge": {
-            "CountMax": 1,
-            "CountStart": 1,
-            "CountUse": 1,
-            "Flags": {
-              "EnableChargeTimeQueuing": 1
-            },
-            "Link": "WarpGateTrain",
-            "TimeStart": 30,
-            "TimeUse": 28
+            "TimeUse": "30.8"
           },
           "Cooldown": {
             "TimeUse": "0"
           },
-          "Time": "16",
-          "Unit": "Zealot",
-          "index": "Train1"
+          "Time": "5.6",
+          "Unit": "Sentry",
+          "index": "Train6"
+        },
+        {
+          "Button": {
+            "Flags": {
+              "ToSelection": 1
+            }
+          },
+          "Charge": {
+            "TimeUse": "30.8"
+          },
+          "Cooldown": {
+            "TimeUse": "0"
+          },
+          "Time": "5.6",
+          "Unit": "Stalker",
+          "index": "Train2"
+        },
+        {
+          "Button": {
+            "Flags": {
+              "ToSelection": 1
+            }
+          },
+          "Charge": {
+            "TimeUse": "49"
+          },
+          "Cooldown": {
+            "TimeUse": "0"
+          },
+          "Time": "5.6",
+          "Unit": "DarkTemplar",
+          "index": "Train5"
+        },
+        {
+          "Button": {
+            "Flags": {
+              "ToSelection": 1
+            }
+          },
+          "Charge": {
+            "TimeUse": "49"
+          },
+          "Cooldown": {
+            "TimeUse": "0"
+          },
+          "Time": "5.6",
+          "Unit": "HighTemplar",
+          "index": "Train4"
         }
       ],
       "id": 1432,
@@ -9479,35 +9523,13 @@
     },
     "WarpPrismTransport": {
       "AbilSetId": "ULdM",
-      "CmdButtonArray": [
-        {
-          "DefaultButtonFace": "BunkerUnloadAll",
-          "Flags": {
-            "ToSelection": 1
-          },
-          "index": "UnloadAll"
+      "CmdButtonArray": {
+        "DefaultButtonFace": "LoadNearbyWarpPrism",
+        "Flags": {
+          "Hidden": 0
         },
-        {
-          "DefaultButtonFace": "MedivacLoad",
-          "index": "Load"
-        },
-        {
-          "DefaultButtonFace": "MedivacUnloadAll",
-          "index": "UnloadAt"
-        },
-        {
-          "Flags": {
-            "Hidden": 1
-          },
-          "index": "LoadAll"
-        },
-        {
-          "Flags": {
-            "Hidden": 1
-          },
-          "index": "UnloadUnit"
-        }
-      ],
+        "index": "LoadAll"
+      },
       "EditorCategories": "Race:Protoss,AbilityorEffectType:Units",
       "Flags": {
         "CargoDeath": 1
@@ -9517,6 +9539,7 @@
       "MaxCargoCount": 8,
       "MaxCargoSize": 8,
       "Range": 5,
+      "SearchRadius": 5,
       "TargetFilters": "Visible;Ally,Neutral,Enemy,Buried,UnderConstruction,Dead,Hidden",
       "TotalCargoSpace": 8,
       "UnloadCargoEffect": "WarpPrismUnloadCargoSetEffect",
@@ -9870,8 +9893,8 @@
             "State": "Restricted"
           },
           "Resource": {
-            "Minerals": 150,
-            "Vespene": 150
+            "Minerals": 100,
+            "Vespene": 100
           },
           "Time": "160",
           "Upgrade": "ZergGroundArmorsLevel1",
@@ -9884,8 +9907,8 @@
             "State": "Restricted"
           },
           "Resource": {
-            "Minerals": 200,
-            "Vespene": 200
+            "Minerals": 150,
+            "Vespene": 150
           },
           "Time": "190",
           "Upgrade": "ZergGroundArmorsLevel2",
@@ -9898,8 +9921,8 @@
             "State": "Restricted"
           },
           "Resource": {
-            "Minerals": 250,
-            "Vespene": 250
+            "Minerals": 200,
+            "Vespene": 200
           },
           "Time": "220",
           "Upgrade": "ZergGroundArmorsLevel3",
@@ -10518,9 +10541,14 @@
         "Armored": 1,
         "Structure": 1
       },
-      "BehaviorArray": {
-        "Link": "WorkerPeriodicRefineryCheck"
-      },
+      "BehaviorArray": [
+        {
+          "Link": "SCVMoveToGatherSeek"
+        },
+        {
+          "Link": "WorkerPeriodicRefineryCheck"
+        }
+      ],
       "BuildOnAs": "AssimilatorRich",
       "BuiltOn": {
         "value": "PurifierVespeneGeyser"
@@ -12034,7 +12062,7 @@
       "SeparationRadius": 1.25,
       "Sight": 12,
       "Speed": 1.875,
-      "SubgroupPriority": 80,
+      "SubgroupPriority": 76,
       "TacticalAIThink": "AIThinkBattleCruiser",
       "TechAliasArray": "Alias_BattlecruiserClass",
       "VisionHeight": 15,
@@ -13158,7 +13186,7 @@
       "CargoSize": 8,
       "Collide": {
         "Colossus": 1,
-        "Flying": 1,
+        "Flying": 0,
         "Structure": 1
       },
       "CostCategory": "Army",
@@ -13399,7 +13427,7 @@
         "UseLineOfSight": 1
       },
       "FogVisibility": "Snapshot",
-      "Food": 15,
+      "Food": 13,
       "Footprint": "Footprint5x5Contour",
       "GlossaryPriority": 30,
       "HotkeyCategory": "Unit/Category/TerranUnits",
@@ -13556,7 +13584,7 @@
         "TownAlert": 1,
         "UseLineOfSight": 1
       },
-      "Food": 15,
+      "Food": 13,
       "GlossaryAlias": "CommandCenter",
       "Height": 3.25,
       "HotkeyAlias": "CommandCenter",
@@ -14487,7 +14515,7 @@
       "requires": [
         "DarkShrine"
       ],
-      "time": 55,
+      "time": 60.66,
       "type": "unit"
     },
     "DebrisRampLeft": {
@@ -14830,6 +14858,9 @@
           "Link": "Warpable"
         },
         {
+          "Link": "attack"
+        },
+        {
           "Link": "move"
         },
         {
@@ -14923,6 +14954,7 @@
       "DamageDealtXP": 1,
       "DamageTakenXP": 1,
       "DeathRevealRadius": 3,
+      "DefaultAcquireLevel": "Defensive",
       "EditorCategories": "ObjectType:Unit,ObjectFamily:Melee",
       "Fidget": {
         "ChanceArray": {
@@ -14981,6 +15013,9 @@
       "SubgroupPriority": 72,
       "TacticalAIThink": "AIThinkDisruptor",
       "TurningRate": 999.8437,
+      "WeaponArray": {
+        "Link": "DisruptorFakeWeapon"
+      },
       "id": 694,
       "name": "Disruptor",
       "race": "Protoss",
@@ -15857,9 +15892,14 @@
         "Biological": 1,
         "Structure": 1
       },
-      "BehaviorArray": {
-        "Link": "WorkerPeriodicRefineryCheck"
-      },
+      "BehaviorArray": [
+        {
+          "Link": "SCVMoveToGatherSeek"
+        },
+        {
+          "Link": "WorkerPeriodicRefineryCheck"
+        }
+      ],
       "BuildOnAs": "ExtractorRich",
       "BuiltOn": {
         "value": "PurifierVespeneGeyser"
@@ -16901,6 +16941,9 @@
           "Link": "GatewayTrain"
         },
         {
+          "Link": "MorphBuildingGatewayWarpGateFree"
+        },
+        {
           "Link": "Rally"
         },
         {
@@ -16920,7 +16963,7 @@
           "Link": "FastEnablerGatewayMorphingPowerSource"
         },
         {
-          "Link": "MorphingintoWarpGate"
+          "Link": "GatewayTrainingState"
         }
       ],
       "CardLayouts": {
@@ -16930,20 +16973,14 @@
             "Column": "4",
             "Face": "CancelBuilding",
             "Row": "2",
-            "Type": "AbilCmd"
+            "Type": "AbilCmd",
+            "index": "10"
           },
           {
-            "AbilCmd": "GatewayTrain,Train1",
-            "Column": "0",
-            "Face": "Zealot",
-            "Row": "0",
-            "Type": "AbilCmd"
-          },
-          {
-            "AbilCmd": "GatewayTrain,Train2",
-            "Column": "2",
-            "Face": "Stalker",
-            "Row": "0",
+            "AbilCmd": "BuildInProgress,Cancel",
+            "Column": "4",
+            "Face": "CancelBuilding",
+            "Row": "2",
             "Type": "AbilCmd"
           },
           {
@@ -16961,6 +16998,21 @@
             "Type": "AbilCmd"
           },
           {
+            "AbilCmd": "GatewayTrain,Train5",
+            "Column": "1",
+            "Face": "DarkTemplar",
+            "Row": "1",
+            "Type": "AbilCmd"
+          },
+          {
+            "AbilCmd": "GatewayTrain,Train6",
+            "Column": "1",
+            "Face": "Sentry",
+            "Row": "0",
+            "Type": "AbilCmd",
+            "index": "8"
+          },
+          {
             "AbilCmd": "GatewayTrain,Train6",
             "Column": "1",
             "Face": "Sentry",
@@ -16971,7 +17023,24 @@
             "AbilCmd": "GatewayTrain,Train7",
             "Column": "3",
             "Face": "WarpInAdept",
+            "Row": "2",
+            "Type": "AbilCmd",
+            "index": "9"
+          },
+          {
+            "AbilCmd": "MorphBuildingGatewayWarpGateFree,Cancel",
+            "Column": "2",
+            "Face": "Stalker",
             "Row": "0",
+            "Type": "AbilCmd",
+            "index": "2"
+          },
+          {
+            "AbilCmd": "MorphBuildingGatewayWarpGateFree,Execute",
+            "Column": 0,
+            "Face": "UpgradeToWarpGate",
+            "Row": 2,
+            "ShowInGlossary": 0,
             "Type": "AbilCmd"
           },
           {
@@ -16980,6 +17049,14 @@
             "Face": "Rally",
             "Row": "1",
             "Type": "AbilCmd"
+          },
+          {
+            "AbilCmd": "UpgradeToWarpGate,Cancel",
+            "Column": "0",
+            "Face": "Cancel",
+            "Row": "0",
+            "Type": "AbilCmd",
+            "index": "1"
           },
           {
             "AbilCmd": "UpgradeToWarpGate,Cancel",
@@ -16996,10 +17073,38 @@
             "Type": "AbilCmd"
           },
           {
-            "AbilCmd": "que5,CancelLast",
-            "Column": "4",
-            "Face": "Cancel",
-            "Row": "2",
+            "AbilCmd": "WarpGateTrain,Train1",
+            "Column": "0",
+            "Face": "Zealot",
+            "Row": "0",
+            "Type": "AbilCmd"
+          },
+          {
+            "AbilCmd": "WarpGateTrain,Train2",
+            "Column": "2",
+            "Face": "Stalker",
+            "Row": "0",
+            "Type": "AbilCmd"
+          },
+          {
+            "AbilCmd": "WarpGateTrain,Train4",
+            "Column": "0",
+            "Face": "HighTemplar",
+            "Row": "1",
+            "Type": "AbilCmd"
+          },
+          {
+            "AbilCmd": "WarpGateTrain,Train6",
+            "Column": "1",
+            "Face": "Sentry",
+            "Row": "0",
+            "Type": "AbilCmd"
+          },
+          {
+            "AbilCmd": "WarpGateTrain,Train7",
+            "Column": "3",
+            "Face": "WarpInAdept",
+            "Row": "0",
             "Type": "AbilCmd"
           }
         ]
@@ -17058,7 +17163,7 @@
       "ShieldsStart": 500,
       "Sight": 9,
       "StationaryTurningRate": 719.4726,
-      "SubgroupPriority": 24,
+      "SubgroupPriority": 30,
       "TacticalAIThink": "AIThinkGateway",
       "TechAliasArray": "Alias_Gateway",
       "TechTreeProducedUnitArray": {
@@ -17216,7 +17321,7 @@
         "PreventDestroy": 1,
         "UseLineOfSight": 1
       },
-      "Food": -2,
+      "Food": -3,
       "GlossaryCategory": "Unit/Category/TerranUnits",
       "GlossaryPriority": 70,
       "GlossaryStrongArray": {
@@ -17233,8 +17338,8 @@
       "KillXP": 30,
       "LateralAcceleration": 46.0625,
       "LifeArmorName": "Unit/LifeArmorName/TerranInfantryArmor",
-      "LifeMax": 125,
-      "LifeStart": 125,
+      "LifeMax": 100,
+      "LifeStart": 100,
       "MinimapRadius": 0.375,
       "Mob": "Multiplayer",
       "PlaneArray": {
@@ -17248,7 +17353,7 @@
       "ScoreResult": "BuildOrder",
       "SeparationRadius": 0.375,
       "Sight": 11,
-      "Speed": 2.8125,
+      "Speed": 2.75,
       "StationaryTurningRate": 999.8437,
       "SubgroupPriority": 82,
       "TacticalAIThink": "AIThinkGhost",
@@ -17526,7 +17631,7 @@
         "PreventDestroy": 1,
         "UseLineOfSight": 1
       },
-      "Food": -2,
+      "Food": -3,
       "GlossaryCategory": "",
       "GlossaryPriority": 70,
       "GlossaryStrongArray": {
@@ -17541,8 +17646,8 @@
       "KillXP": 30,
       "LateralAcceleration": 46.0625,
       "LifeArmorName": "Unit/LifeArmorName/TerranInfantryArmor",
-      "LifeMax": 125,
-      "LifeStart": 125,
+      "LifeMax": 100,
+      "LifeStart": 100,
       "MinimapRadius": 0.375,
       "Mob": "Multiplayer",
       "PlaneArray": {
@@ -17556,7 +17661,7 @@
       "ScoreResult": "BuildOrder",
       "SeparationRadius": 0.375,
       "Sight": 11,
-      "Speed": 2.8125,
+      "Speed": 2.75,
       "StationaryTurningRate": 999.8437,
       "SubgroupPriority": 82,
       "TacticalAIThink": "AIThinkGhost",
@@ -17701,7 +17806,7 @@
         "PreventDestroy": 1,
         "UseLineOfSight": 1
       },
-      "Food": -2,
+      "Food": -3,
       "GlossaryCategory": "",
       "GlossaryPriority": 70,
       "GlossaryStrongArray": {
@@ -17716,8 +17821,8 @@
       "KillXP": 30,
       "LateralAcceleration": 46.0625,
       "LifeArmorName": "Unit/LifeArmorName/TerranInfantryArmor",
-      "LifeMax": 125,
-      "LifeStart": 125,
+      "LifeMax": 100,
+      "LifeStart": 100,
       "MinimapRadius": 0.375,
       "Mob": "Multiplayer",
       "PlaneArray": {
@@ -17731,7 +17836,7 @@
       "ScoreResult": "BuildOrder",
       "SeparationRadius": 0.375,
       "Sight": 11,
-      "Speed": 2.8125,
+      "Speed": 2.75,
       "StationaryTurningRate": 999.8437,
       "SubgroupPriority": 82,
       "TacticalAIThink": "AIThinkGhost",
@@ -18263,7 +18368,7 @@
       },
       "CostCategory": "Economy",
       "CostResource": {
-        "Minerals": 325
+        "Minerals": 350
       },
       "DeathRevealRadius": 3,
       "EditorCategories": "ObjectType:Structure,ObjectFamily:Melee",
@@ -18283,7 +18388,7 @@
         "UseLineOfSight": 1
       },
       "FogVisibility": "Snapshot",
-      "Food": 6,
+      "Food": 4,
       "Footprint": "Footprint6x5DropOffCreepSourceContour",
       "GlossaryPriority": 10,
       "HotkeyCategory": "Unit/Category/ZergUnits",
@@ -18689,6 +18794,7 @@
         }
       ],
       "Acceleration": 1000,
+      "AcquireMovementLimit": 5.5,
       "AttackTargetPriority": 20,
       "Attributes": {
         "Biological": 1,
@@ -18861,7 +18967,7 @@
       "requires": [
         "TemplarArchive"
       ],
-      "time": 55,
+      "time": 60.66,
       "type": "unit"
     },
     "Hive": {
@@ -18972,7 +19078,7 @@
       },
       "CostCategory": "Technology",
       "CostResource": {
-        "Minerals": 675,
+        "Minerals": 700,
         "Vespene": 250
       },
       "DeathRevealRadius": 3,
@@ -18989,7 +19095,7 @@
         "UseLineOfSight": 1
       },
       "FogVisibility": "Snapshot",
-      "Food": 6,
+      "Food": 4,
       "Footprint": "Footprint6x5DropOffCreepSourceContour",
       "GlossaryPriority": 18,
       "HotkeyCategory": "Unit/Category/ZergUnits",
@@ -19714,9 +19820,8 @@
             "index": "2"
           },
           {
-            "AbilCmd": "InfestationPitResearch,Research6",
-            "Face": "AmorphousArmorcloud",
-            "index": "3"
+            "index": "3",
+            "removed": "1"
           }
         ]
       },
@@ -19822,6 +19927,9 @@
           "Link": "NeuralParasite"
         },
         {
+          "Link": "attack"
+        },
+        {
           "Link": "move"
         },
         {
@@ -19829,6 +19937,7 @@
         }
       ],
       "Acceleration": 1000,
+      "AcquireMovementLimit": 5.5,
       "AttackTargetPriority": 20,
       "Attributes": {
         "Armored": 1,
@@ -20136,6 +20245,9 @@
       "SubgroupPriority": 94,
       "TacticalAIThink": "AIThinkInfestor",
       "TurningRate": 999.8437,
+      "WeaponArray": {
+        "Link": "InfestorWeaponAcidSpores"
+      },
       "id": 111,
       "name": "Infestor",
       "race": "Zerg",
@@ -20558,7 +20670,7 @@
       },
       "CostCategory": "Technology",
       "CostResource": {
-        "Minerals": 475,
+        "Minerals": 500,
         "Vespene": 100
       },
       "DeathRevealRadius": 3,
@@ -20575,7 +20687,7 @@
         "UseLineOfSight": 1
       },
       "FogVisibility": "Snapshot",
-      "Food": 6,
+      "Food": 4,
       "Footprint": "Footprint6x5DropOffCreepSourceContour",
       "GlossaryPriority": 14,
       "HotkeyCategory": "Unit/Category/ZergUnits",
@@ -20744,7 +20856,7 @@
         "Ground": 1
       },
       "Race": "Zerg",
-      "Radius": 0.125,
+      "Radius": 0.3125,
       "SeparationRadius": 0,
       "Sight": 5,
       "Speed": 0.5625,
@@ -21453,7 +21565,7 @@
       "Sight": 10,
       "Speed": 2.25,
       "StationaryTurningRate": 999.8437,
-      "SubgroupPriority": 76,
+      "SubgroupPriority": 78,
       "TauntDuration": {
         "Cheer": 5,
         "Dance": 5
@@ -21598,7 +21710,7 @@
       "Sight": 9,
       "Speed": 2.25,
       "StationaryTurningRate": 999.8437,
-      "SubgroupPriority": 78,
+      "SubgroupPriority": 80,
       "TauntDuration": {
         "Cheer": 5,
         "Dance": 5
@@ -21669,6 +21781,13 @@
             "Column": "2",
             "Face": "MedivacLoad",
             "Row": "2",
+            "Type": "AbilCmd"
+          },
+          {
+            "AbilCmd": "MedivacTransport,LoadAll",
+            "Column": "2",
+            "Face": "LoadNearbyMedivac",
+            "Row": "1",
             "Type": "AbilCmd"
           },
           {
@@ -22122,6 +22241,7 @@
         }
       ],
       "Acceleration": 3.5,
+      "AcquireMovementLimit": 8,
       "AttackTargetPriority": 20,
       "Attributes": {
         "Biological": 1,
@@ -22257,9 +22377,6 @@
           "Link": "EnergyRecharge"
         },
         {
-          "Link": "EnergyRecharge"
-        },
-        {
           "Link": "NexusInvulnerability"
         },
         {
@@ -22310,7 +22427,7 @@
         "Structure": 1
       },
       "BehaviorArray": {
-        "Link": "FastEnablerPowerSourceNexus"
+        "Link": "NexusDeath"
       },
       "CardLayouts": {
         "LayoutButtons": [
@@ -22381,7 +22498,7 @@
         "UseLineOfSight": 1
       },
       "FogVisibility": "Snapshot",
-      "Food": 15,
+      "Food": 13,
       "Footprint": "Footprint5x5Contour",
       "GlossaryPriority": 10,
       "HotkeyCategory": "Unit/Category/ProtossUnits",
@@ -22711,6 +22828,7 @@
         }
       ],
       "Acceleration": 3,
+      "AcquireMovementLimit": 8,
       "AttackTargetPriority": 20,
       "Attributes": [
         {
@@ -22982,7 +23100,7 @@
       "id": 732,
       "name": "OracleStasisTrap",
       "race": "Protoss",
-      "time": 5,
+      "time": 5.6,
       "type": "structure"
     },
     "OrbitalCommand": {
@@ -23114,7 +23232,7 @@
         "UseLineOfSight": 1
       },
       "FogVisibility": "Snapshot",
-      "Food": 15,
+      "Food": 13,
       "Footprint": "Footprint5x5Contour",
       "GlossaryPriority": 32,
       "HotkeyCategory": "Unit/Category/TerranUnits",
@@ -23257,7 +23375,7 @@
         "TownAlert": 1,
         "UseLineOfSight": 1
       },
-      "Food": 15,
+      "Food": 13,
       "GlossaryAlias": "OrbitalCommand",
       "Height": 3.75,
       "HotkeyAlias": "OrbitalCommand",
@@ -23362,7 +23480,7 @@
       "Height": 3.75,
       "HotkeyCategory": "Unit/Category/ZergUnits",
       "KillXP": 20,
-      "LateralAcceleration": 46.0625,
+      "LateralAcceleration": 1,
       "LifeArmorName": "Unit/LifeArmorName/ZergAirArmor",
       "LifeMax": 200,
       "LifeRegenRate": 0.2734,
@@ -23381,11 +23499,11 @@
       "ScoreResult": "BuildOrder",
       "SeparationRadius": 0.75,
       "Sight": 11,
-      "Speed": 0.6445,
-      "StationaryTurningRate": 999.8437,
+      "Speed": 0.6054,
+      "StationaryTurningRate": 499.9218,
       "SubgroupPriority": 72,
       "TechAliasArray": "Alias_Overlord",
-      "TurningRate": 999.8437,
+      "TurningRate": 499.9218,
       "VisionHeight": 15,
       "id": 106,
       "morphsto": [
@@ -23580,6 +23698,13 @@
             "Type": "AbilCmd"
           },
           {
+            "AbilCmd": "OverlordTransport,LoadAll",
+            "Column": "2",
+            "Face": "LoadNearbyOverlord",
+            "Row": "1",
+            "Type": "AbilCmd"
+          },
+          {
             "AbilCmd": "OverlordTransport,UnloadAt",
             "Column": "3",
             "Face": "OverlordTransportUnload",
@@ -23674,10 +23799,10 @@
       "SeparationRadius": 0.75,
       "Sight": 11,
       "Speed": 0.914,
-      "StationaryTurningRate": 999.8437,
+      "StationaryTurningRate": 719.4726,
       "SubgroupPriority": 73,
       "TechAliasArray": "Alias_Overlord",
-      "TurningRate": 999.8437,
+      "TurningRate": 719.4726,
       "VisionHeight": 15,
       "id": 893,
       "morphsto": [
@@ -24228,7 +24353,7 @@
         "UseLineOfSight": 1
       },
       "FogVisibility": "Snapshot",
-      "Food": 15,
+      "Food": 13,
       "Footprint": "Footprint5x5Contour",
       "GlossaryCategory": "Unit/Category/TerranUnits",
       "GlossaryPriority": 240,
@@ -24611,14 +24736,9 @@
         "Armored": 1,
         "Structure": 1
       },
-      "BehaviorArray": [
-        {
-          "Link": "FastEnablerPowerUser"
-        },
-        {
-          "Link": "PowerSourceFast"
-        }
-      ],
+      "BehaviorArray": {
+        "Link": "PowerSource"
+      },
       "CardLayouts": {
         "LayoutButtons": [
           {
@@ -25018,8 +25138,8 @@
       "Race": "Zerg",
       "Radius": 0.875,
       "RankDisplay": "Always",
-      "ScoreKill": 175,
-      "ScoreMake": 175,
+      "ScoreKill": 150,
+      "ScoreMake": 150,
       "ScoreResult": "BuildOrder",
       "SeparationRadius": 0.875,
       "Sight": 9,
@@ -25075,6 +25195,7 @@
         }
       ],
       "Acceleration": 1000,
+      "AcquireMovementLimit": 11,
       "AttackTargetPriority": 20,
       "Attributes": {
         "Biological": 1
@@ -25582,10 +25703,9 @@
       "GlossaryWeakArray": {
         "0": "VikingFighter",
         "1": "Mutalisk",
-        "2": "HighTemplar",
         "value": "Ghost"
       },
-      "Height": 3.75,
+      "Height": 4.15,
       "HotkeyCategory": "Unit/Category/TerranUnits",
       "KillDisplay": "Always",
       "KillXP": 45,
@@ -25610,7 +25730,7 @@
       "Sight": 11,
       "Speed": 2.9492,
       "StationaryTurningRate": 999.8437,
-      "SubgroupPriority": 84,
+      "SubgroupPriority": 77,
       "TacticalAIThink": "AIThinkRaven",
       "TurningRate": 999.8437,
       "VisionHeight": 15,
@@ -25764,9 +25884,14 @@
         "Mechanical": 1,
         "Structure": 1
       },
-      "BehaviorArray": {
-        "Link": "WorkerPeriodicRefineryCheck"
-      },
+      "BehaviorArray": [
+        {
+          "Link": "SCVMoveToGatherSeek"
+        },
+        {
+          "Link": "WorkerPeriodicRefineryCheck"
+        }
+      ],
       "BuildOnAs": "RefineryRich",
       "BuiltOn": {
         "value": "PurifierVespeneGeyser"
@@ -25868,9 +25993,14 @@
         "Mechanical": 1,
         "Structure": 1
       },
-      "BehaviorArray": {
-        "Link": "WorkerPeriodicRefineryCheck"
-      },
+      "BehaviorArray": [
+        {
+          "Link": "SCVMoveToGatherSeek"
+        },
+        {
+          "Link": "WorkerPeriodicRefineryCheck"
+        }
+      ],
       "BuiltOn": "RichVespeneGeyser",
       "CardLayouts": {
         "LayoutButtons": [
@@ -26187,6 +26317,7 @@
             "AbilCmd": "stop,Stop",
             "Column": "1",
             "Face": "Stop",
+            "Requirements": "UseBurrow",
             "Row": "0",
             "Type": "AbilCmd",
             "index": "5"
@@ -27529,7 +27660,7 @@
       "requires": [
         "CyberneticsCore"
       ],
-      "time": 32,
+      "time": 32.66,
       "type": "unit"
     },
     "ShieldBattery": {
@@ -27554,7 +27685,7 @@
         "Structure": 1
       },
       "BehaviorArray": {
-        "Link": "BatteryEnergy"
+        "Link": "PowerUserQueueSmall"
       },
       "CardLayouts": {
         "LayoutButtons": [
@@ -27601,7 +27732,7 @@
       "EditorCategories": "ObjectType:Structure,ObjectFamily:Melee",
       "EnergyMax": 100,
       "EnergyRegenRate": 0.5625,
-      "EnergyStart": 50,
+      "EnergyStart": 75,
       "FlagArray": {
         "AIDefense": 1,
         "ArmorDisabledWhileConstructing": 1,
@@ -29649,6 +29780,9 @@
       "DeathRevealRadius": 3,
       "Description": "Button/Tooltip/SwarmHostMP",
       "EditorCategories": "ObjectType:Unit,ObjectFamily:Melee",
+      "EquipmentArray": {
+        "Weapon": "AcidSpitSwarmhostDummy"
+      },
       "Facing": 45,
       "FlagArray": [
         {
@@ -29727,9 +29861,6 @@
       "Attributes": {
         "Armored": 1,
         "Biological": 1
-      },
-      "BehaviorArray": {
-        "Link": "TrainInfestedTerran"
       },
       "CardLayouts": {
         "LayoutButtons": [
@@ -29926,6 +30057,9 @@
       },
       "DeathRevealRadius": 3,
       "EditorCategories": "ObjectType:Unit,ObjectFamily:Melee",
+      "EquipmentArray": {
+        "Weapon": "AcidSpitSwarmhostDummy"
+      },
       "FlagArray": {
         "AIHighPrioTarget": 1,
         "AIPreferBurrow": 1,
@@ -31664,6 +31798,13 @@
       "CardLayouts": {
         "LayoutButtons": [
           {
+            "AbilCmd": "MorphBackToGateway,Cancel",
+            "Column": "4",
+            "Face": "Cancel",
+            "Row": "2",
+            "Type": "AbilCmd"
+          },
+          {
             "AbilCmd": "MorphBackToGateway,Execute",
             "Column": "1",
             "Face": "MorphBackToGateway",
@@ -31718,6 +31859,12 @@
             "Face": "WarpInAdept",
             "Row": "0",
             "Type": "AbilCmd"
+          },
+          {
+            "Column": "0",
+            "Face": "UpgradeToWarpGate",
+            "Row": "2",
+            "Type": "AbilCmd"
           }
         ]
       },
@@ -31736,6 +31883,10 @@
       },
       "DeathRevealRadius": 3,
       "EditorCategories": "ObjectType:Structure,ObjectFamily:Melee",
+      "EffectArray": {
+        "Birth": "HasMorphedBefore",
+        "Create": "HasMorphedBefore"
+      },
       "Facing": 315,
       "FlagArray": {
         "ArmorDisabledWhileConstructing": 1,
@@ -31775,7 +31926,7 @@
       "ShieldsStart": 500,
       "Sight": 9,
       "StationaryTurningRate": 719.4726,
-      "SubgroupPriority": 30,
+      "SubgroupPriority": 24,
       "TechAliasArray": "Alias_Gateway",
       "TurningRate": 719.4726,
       "id": 133,
@@ -31818,6 +31969,9 @@
         "Mechanical": 1,
         "Psionic": 1
       },
+      "BehaviorArray": {
+        "Link": "WarpPrismLoadupDecelerationFix"
+      },
       "CardLayouts": {
         "LayoutButtons": [
           {
@@ -31832,6 +31986,13 @@
             "Column": "2",
             "Face": "WarpPrismLoad",
             "Row": "2",
+            "Type": "AbilCmd"
+          },
+          {
+            "AbilCmd": "WarpPrismTransport,LoadAll",
+            "Column": "2",
+            "Face": "LoadNearbyWarpPrism",
+            "Row": "1",
             "Type": "AbilCmd"
           },
           {
@@ -31908,7 +32069,7 @@
       "GlossaryWeakArray": {
         "value": "MissileTurret"
       },
-      "Height": 3.75,
+      "Height": 4.25,
       "HotkeyCategory": "Unit/Category/ProtossUnits",
       "KillXP": 35,
       "LateralAcceleration": 57,
@@ -33298,17 +33459,17 @@
       "time": 220
     },
     "ZergGroundArmorsLevel1": {
-      "gas": 150,
+      "gas": 100,
       "id": 56,
-      "minerals": 150,
+      "minerals": 100,
       "name": "ZergGroundArmorsLevel1",
       "requires": [],
       "time": 160
     },
     "ZergGroundArmorsLevel2": {
-      "gas": 200,
+      "gas": 150,
       "id": 57,
-      "minerals": 200,
+      "minerals": 150,
       "name": "ZergGroundArmorsLevel2",
       "requires": [
         "Lair",
@@ -33317,9 +33478,9 @@
       "time": 190
     },
     "ZergGroundArmorsLevel3": {
-      "gas": 250,
+      "gas": 200,
       "id": 58,
-      "minerals": 250,
+      "minerals": 200,
       "name": "ZergGroundArmorsLevel3",
       "requires": [
         "Hive",

--- a/src/game_logic/execute_action.ts
+++ b/src/game_logic/execute_action.ts
@@ -512,7 +512,21 @@ const executeAction = (gamelogic: GameLogic, actionItem: IBuildOrderElement): bo
                 type: "upgrade",
             },
         ]
-        if (gamelogic.upgrades.has("WarpGateResearch")) {
+        if (gamelogic.minerals < 25) {
+            gamelogic.errorMessage = "25 minerals required"
+        } else if (gamelogic.vespene < 25) {
+            gamelogic.errorMessage = `Unable to afford convert gateway to warpgate, missing ${Math.ceil(
+                25 - gamelogic.vespene,
+            )} vespene.`
+            if (gamelogic.workersVespene === 0) {
+                gamelogic.requirements = [
+                    {
+                        name: "3worker_to_gas",
+                        type: "action",
+                    },
+                ]
+            }
+        } else if (gamelogic.upgrades.has("WarpGateResearch")) {
             gamelogic.errorMessage = "Could not find a gateway."
             for (const unit of gamelogic.idleUnits) {
                 if (unit.name === "Gateway" && !unit.isBusy()) {
@@ -520,6 +534,8 @@ const executeAction = (gamelogic: GameLogic, actionItem: IBuildOrderElement): bo
                     task.morphToUnit = "WarpGate"
                     unit.addTask(gamelogic, task)
                     actionCompleted = true
+                    gamelogic.minerals -= 25
+                    gamelogic.vespene -= 25
                     break
                 }
             }
@@ -540,6 +556,8 @@ const executeAction = (gamelogic: GameLogic, actionItem: IBuildOrderElement): bo
                 task.morphToUnit = "Gateway"
                 unit.addTask(gamelogic, task)
                 actionCompleted = true
+                gamelogic.minerals += 25
+                gamelogic.vespene += 25
                 break
             }
         }

--- a/src/game_logic/gamelogic.test.ts
+++ b/src/game_logic/gamelogic.test.ts
@@ -341,11 +341,17 @@ test("Add BroodLord with required tech", () => {
 })
 
 test("Add ZergFlyerWeaponsLevel3 with required tech", () => {
-    const prevLogic = new GameLogic("zerg", [])
+    const prevLogic = new GameLogic("zerg", [
+        { name: "Drone", type: "worker" },
+        { name: "Drone", type: "worker" },
+        { name: "Overlord", type: "unit" },
+        { name: "Drone", type: "worker" },
+        { name: "Drone", type: "worker" },
+    ])
     const [logic, insertedItems] = GameLogic.addItemToBO(
         prevLogic,
         { name: "ZergFlyerWeaponsLevel3", type: "upgrade" },
-        0,
+        prevLogic.bo.length,
     )
     // This should not insert GreaterSpire as it is not required
 
@@ -353,9 +359,9 @@ test("Add ZergFlyerWeaponsLevel3 with required tech", () => {
     expect(logic.upgrades.has("ZergFlyerWeaponsLevel2")).toBe(true)
     expect(logic.upgrades.has("ZergFlyerWeaponsLevel3")).toBe(true)
     expect(insertedItems).toBe(10)
-    expect(logic.units.size).toBe(14)
-    expect(logic.eventLog.length).toBe(10)
-    expect(logic.supplyCap).toBe(14)
+    expect(logic.units.size).toBe(15)
+    expect(logic.eventLog.length).toBe(15)
+    expect(logic.supplyCap).toBe(20)
 })
 
 test("Add two Archons with required tech", () => {

--- a/src/game_logic/gamelogic.test.ts
+++ b/src/game_logic/gamelogic.test.ts
@@ -19,9 +19,9 @@ test("Get the train cost of Depot", () => {
 })
 
 test("Get the train cost of Hatchery", () => {
-    expect(GameLogic.getCost("Hatchery").minerals).toBe(275)
+    expect(GameLogic.getCost("Hatchery").minerals).toBe(300)
     expect(GameLogic.getCost("Hatchery").vespene).toBe(0)
-    expect(GameLogic.getCost("Hatchery").supply).toBe(-6)
+    expect(GameLogic.getCost("Hatchery").supply).toBe(-4)
 })
 
 test("Get the train cost of Lair", () => {

--- a/src/game_logic/gamelogic.test.ts
+++ b/src/game_logic/gamelogic.test.ts
@@ -48,7 +48,7 @@ test("Build an SCV", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(14)
+    expect(logic.units.size).toBe(10)
     expect(logic.eventLog.length).toBe(1)
 })
 
@@ -61,7 +61,7 @@ test("Build two SCVs", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(15)
+    expect(logic.units.size).toBe(11)
     expect(logic.eventLog.length).toBe(2)
 })
 
@@ -71,7 +71,7 @@ test("Build depot", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(14)
+    expect(logic.units.size).toBe(10)
     expect(logic.eventLog.length).toBe(1)
 })
 
@@ -83,24 +83,24 @@ test("Build SCV then depot", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(15)
-    expect(logic.supplyCap).toBe(23)
+    expect(logic.units.size).toBe(11)
+    expect(logic.supplyCap).toBe(21)
     expect(logic.eventLog.length).toBe(2)
 })
 
-test("Build 4 SCVs", () => {
+test("Build 6 SCVs", () => {
     // Test to see if supply block matters
     const bo: IBuildOrderElement[] = []
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 6; i++) {
         bo.push({ name: "SCV", type: "worker" })
     }
-    expect(bo.length).toBe(4)
+    expect(bo.length).toBe(6)
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    // Should be 17 but since we get supply blocked, only get up to 16 units max (15 workers + 1 cc)
-    expect(logic.units.size).toBe(16)
-    expect(logic.eventLog.length).toBe(3)
+    // Should be 14 but since we get supply blocked, only get up to 14 units max (13 workers + 1 cc)
+    expect(logic.units.size).toBe(14)
+    expect(logic.eventLog.length).toBe(5)
 })
 
 test("Build 3 SCVs then depot then one more SCV", () => {
@@ -115,9 +115,8 @@ test("Build 3 SCVs then depot then one more SCV", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    // Should be 17 but since we get supply blocked, only get up to 16 units max (15 workers + 1 cc)
-    expect(logic.supplyCap).toBe(23)
-    expect(logic.units.size).toBe(18)
+    expect(logic.supplyCap).toBe(21)
+    expect(logic.units.size).toBe(14)
     expect(logic.eventLog.length).toBe(5)
 })
 
@@ -128,7 +127,7 @@ test("Build commandcenter", () => {
     logic.settings.idleLimit = 50
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(14)
+    expect(logic.units.size).toBe(10)
     expect(logic.eventLog.length).toBe(1)
 })
 
@@ -138,7 +137,7 @@ test("Build refinery", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(14)
+    expect(logic.units.size).toBe(10)
     expect(logic.eventLog.length).toBe(1)
 })
 
@@ -172,9 +171,9 @@ test("Build 2 drones, 1 overlord, 4 drones", () => {
     const logic = new GameLogic("zerg", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(21)
+    expect(logic.units.size).toBe(17)
     expect(logic.eventLog.length).toBe(7)
-    expect(logic.supplyCap).toBe(22)
+    expect(logic.supplyCap).toBe(20)
 })
 
 test("Test spore requirements", () => {
@@ -185,9 +184,9 @@ test("Test spore requirements", () => {
     const logic = new GameLogic("zerg", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(14)
+    expect(logic.units.size).toBe(10)
     expect(logic.eventLog.length).toBe(2)
-    expect(logic.supplyCap).toBe(14)
+    expect(logic.supplyCap).toBe(12)
 })
 
 test("Build OC and call down MULE", () => {
@@ -201,7 +200,7 @@ test("Build OC and call down MULE", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(16)
+    expect(logic.units.size).toBe(12)
     expect(logic.eventLog.length).toBe(4)
 })
 
@@ -216,7 +215,7 @@ test("Test if able to create a gas unit (reaper)", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(17)
+    expect(logic.units.size).toBe(13)
     expect(logic.eventLog.length).toBe(5)
 })
 
@@ -231,7 +230,7 @@ test("Test if able to research +1 from ebay", () => {
     const logic = new GameLogic("terran", bo)
     logic.setStart()
     logic.runUntilEnd()
-    expect(logic.units.size).toBe(16)
+    expect(logic.units.size).toBe(12)
     expect(logic.upgrades.has("TerranInfantryWeaponsLevel1")).toBe(true)
     expect(logic.eventLog.length).toBe(5)
 })
@@ -256,7 +255,7 @@ test("Test if able to research +2 from ebay after requirements are met", () => {
     logic.runUntilEnd()
     expect(logic.upgrades.has("TerranInfantryWeaponsLevel1")).toBe(true)
     expect(logic.upgrades.has("TerranInfantryWeaponsLevel2")).toBe(true)
-    expect(logic.units.size).toBe(21)
+    expect(logic.units.size).toBe(17)
     expect(logic.eventLog.length).toBe(12)
 })
 
@@ -280,7 +279,7 @@ test("Test if able upgrade to PF", () => {
         }
     })
     expect(pfCount).toBe(1)
-    expect(logic.units.size).toBe(17)
+    expect(logic.units.size).toBe(13)
     expect(logic.eventLog.length).toBe(7)
 })
 
@@ -317,7 +316,7 @@ test("Test if able lift Barracks from reactor and let factory attach to it", () 
     })
     expect(factoryReactorCount).toBe(1)
 
-    expect(logic.units.size).toBe(17)
+    expect(logic.units.size).toBe(13)
     expect(logic.eventLog.length).toBe(8)
 })
 
@@ -326,9 +325,9 @@ test("Add Battlecruiser with required tech", () => {
     const [logic, insertedItems] = GameLogic.addItemToBO(prevLogic, { name: "Battlecruiser", type: "unit" }, 0)
 
     expect(insertedItems).toBe(9)
-    expect(logic.units.size).toBe(20)
+    expect(logic.units.size).toBe(16)
     expect(logic.eventLog.length).toBe(9)
-    expect(logic.supplyCap).toBe(23)
+    expect(logic.supplyCap).toBe(21)
 })
 
 test("Add BroodLord with required tech", () => {
@@ -336,9 +335,9 @@ test("Add BroodLord with required tech", () => {
     const [logic, insertedItems] = GameLogic.addItemToBO(prevLogic, { name: "BroodLord", type: "unit" }, 0)
 
     expect(insertedItems).toBe(10)
-    expect(logic.units.size).toBe(15)
-    expect(logic.eventLog.length).toBe(10)
-    expect(logic.supplyCap).toBe(14)
+    expect(logic.units.size).toBe(10)
+    expect(logic.eventLog.length).toBe(6)
+    expect(logic.supplyCap).toBe(12)
 })
 
 test("Add ZergFlyerWeaponsLevel3 with required tech", () => {
@@ -368,9 +367,9 @@ test("Add two Archons with required tech", () => {
     )
 
     expect(insertedItems).toBe(11)
-    expect(logic.units.size).toBe(21)
+    expect(logic.units.size).toBe(17)
     expect(logic.eventLog.length).toBe(11)
-    expect(logic.supplyCap).toBe(31)
+    expect(logic.supplyCap).toBe(29)
     ;[logic, insertedItems] = GameLogic.addItemToBO(
         logic,
         { name: "morph_archon_from_ht_ht", type: "action" },
@@ -378,9 +377,9 @@ test("Add two Archons with required tech", () => {
     )
 
     expect(insertedItems).toBe(3)
-    expect(logic.units.size).toBe(22)
+    expect(logic.units.size).toBe(18)
     expect(logic.eventLog.length).toBe(14)
-    expect(logic.supplyCap).toBe(31)
+    expect(logic.supplyCap).toBe(29)
 })
 
 test("Add ProtossGroundWeaponsLevel1 with required tech", () => {
@@ -392,9 +391,9 @@ test("Add ProtossGroundWeaponsLevel1 with required tech", () => {
     )
 
     expect(insertedItems).toBe(5) // Pylon, Forge, Assimilator, 3worker_to_gas, PGW1
-    expect(logic.units.size).toBe(16) // Nexus(1) + 12 Probes + Pylon + Forge + Assimilator = 16
+    expect(logic.units.size).toBe(12) // Nexus(1) + 8 Probes + Pylon + Forge + Assimilator = 12
     expect(logic.eventLog.length).toBe(5)
-    expect(logic.supplyCap).toBe(23) // Nexus(15) + Pylon(8) = 23
+    expect(logic.supplyCap).toBe(21) // Nexus(13) + Pylon(8) = 21
     expect(logic.upgrades.has("ProtossGroundWeaponsLevel1")).toBe(true)
 })
 
@@ -403,9 +402,9 @@ test("Add Gateway with required tech", () => {
     const [logic, insertedItems] = GameLogic.addItemToBO(prevLogic, { name: "Gateway", type: "structure" }, 0)
 
     expect(insertedItems).toBe(2) // Pylon, Gateway
-    expect(logic.units.size).toBe(15) // Nexus(1) + 12 Probes + Pylon + Gateway = 15
+    expect(logic.units.size).toBe(11) // Nexus(1) + 8 Probes + Pylon + Gateway = 11
     expect(logic.eventLog.length).toBe(2)
-    expect(logic.supplyCap).toBe(23) // Nexus(15) + Pylon(8) = 23
+    expect(logic.supplyCap).toBe(21) // Nexus(13) + Pylon(8) = 21
 })
 
 test("Add Zealot with required tech", () => {
@@ -413,9 +412,9 @@ test("Add Zealot with required tech", () => {
     const [logic, insertedItems] = GameLogic.addItemToBO(prevLogic, { name: "Zealot", type: "unit" }, 0)
 
     expect(insertedItems).toBe(3) // Pylon, Gateway, Zealot
-    expect(logic.units.size).toBe(16) // Nexus(1) + 12 Probes + Pylon + Gateway + Zealot
+    expect(logic.units.size).toBe(12) // Nexus(1) + 8 Probes + Pylon + Gateway + Zealot
     expect(logic.eventLog.length).toBe(3) // Pylon built, Gateway built, Zealot trained
-    expect(logic.supplyCap).toBe(23) // Nexus(15) + Pylon(8) = 23
+    expect(logic.supplyCap).toBe(21) // Nexus(13) + Pylon(8) = 21
 })
 
 test("Add Zealot via WarpGate path", () => {
@@ -427,16 +426,16 @@ test("Add Zealot via WarpGate path", () => {
     )
 
     expect(insertedItems).toBe(7) // Pylon, Gateway, CyberneticsCore, WarpGateResearch, convert
-    expect(logic.units.size).toBe(17) // Nexus(1) + 12 Probes + Pylon + WarpGate + CyberneticsCore
+    expect(logic.units.size).toBe(13) // Nexus(1) + 8 Probes + Pylon + WarpGate + CyberneticsCore
     expect(logic.eventLog.length).toBe(7) // Pylon, Gateway, CyberneticsCore, WarpGateResearch (no event for morph)
-    expect(logic.supplyCap).toBe(23)
+    expect(logic.supplyCap).toBe(21)
     expect(logic.upgrades.has("WarpGateResearch")).toBe(true)
     ;[logic, insertedItems] = GameLogic.addItemToBO(logic, { name: "Zealot", type: "unit" }, insertedItems)
 
     expect(insertedItems).toBe(1) // Just Zealot (WarpGate already exists)
-    expect(logic.units.size).toBe(18) // +1 Zealot
+    expect(logic.units.size).toBe(14) // +1 Zealot
     expect(logic.eventLog.length).toBe(8) // +1 Zealot train event
-    expect(logic.supplyCap).toBe(23)
+    expect(logic.supplyCap).toBe(21)
 
     // Verify Zealot was produced by WarpGate, not Gateway
     let zealotCount = 0
@@ -463,9 +462,9 @@ test("Add LurkerMP with required tech", () => {
     const [logic, insertedItems] = GameLogic.addItemToBO(prevLogic, { name: "LurkerMP", type: "unit" }, 0)
 
     expect(insertedItems).toBe(8)
-    expect(logic.units.size).toBe(15)
+    expect(logic.units.size).toBe(11)
     expect(logic.eventLog.length).toBe(8)
-    expect(logic.supplyCap).toBe(14)
+    expect(logic.supplyCap).toBe(12)
 })
 
 test("Add GreaterSpire, UltraliskCavern, and Corruptor", () => {
@@ -485,9 +484,9 @@ test("Add GreaterSpire, UltraliskCavern, and Corruptor", () => {
     ;[logic, insertedItems] = GameLogic.addItemToBO(logic, { name: "Corruptor", type: "unit" }, insertedItems)
 
     expect(insertedItems).toBe(1)
-    expect(logic.units.size).toBe(14)
+    expect(logic.units.size).toBe(10)
     expect(logic.eventLog.length).toBe(1)
-    expect(logic.supplyCap).toBe(14)
+    expect(logic.supplyCap).toBe(12)
 })
 
 test("Add Lair then Queen", () => {
@@ -500,9 +499,9 @@ test("Add Lair then Queen", () => {
     ;[logic, insertedItems] = GameLogic.addItemToBO(logic, { name: "Queen", type: "unit" }, insertedItems)
 
     expect(insertedItems).toBe(1)
-    expect(logic.units.size).toBe(15)
+    expect(logic.units.size).toBe(11)
     expect(logic.eventLog.length).toBe(5)
-    expect(logic.supplyCap).toBe(14)
+    expect(logic.supplyCap).toBe(12)
 })
 
 test("Add Hive then Queen", () => {
@@ -515,9 +514,9 @@ test("Add Hive then Queen", () => {
     ;[logic, insertedItems] = GameLogic.addItemToBO(logic, { name: "Queen", type: "unit" }, insertedItems)
 
     expect(insertedItems).toBe(1)
-    expect(logic.units.size).toBe(15)
+    expect(logic.units.size).toBe(11)
     expect(logic.eventLog.length).toBe(7)
-    expect(logic.supplyCap).toBe(14)
+    expect(logic.supplyCap).toBe(12)
 })
 
 test("Add Hive then ZergMissileWeaponsLevel3", () => {
@@ -534,12 +533,14 @@ test("Add Hive then ZergMissileWeaponsLevel3", () => {
     )
 
     // This test may fail because old systems required Lair for Level2. However, that Lair already has morphed to Hive
-    expect(logic.units.size).toBe(14)
+    expect(logic.units.size).toBe(10)
     expect(logic.eventLog.length).toBe(10)
 })
 
 test("Failing: Add drone after extractor trick", () => {
     const bo: IBuildOrderElement[] = [
+        { name: "Drone", type: "worker" },
+        { name: "Drone", type: "worker" },
         { name: "Drone", type: "worker" },
         { name: "Drone", type: "worker" },
         { name: "Extractor", type: "structure" },
@@ -551,14 +552,16 @@ test("Failing: Add drone after extractor trick", () => {
     logic.setStart()
     logic.runUntilEnd()
     expect(logic.supplyLeft).toBe(0)
-    expect(logic.supplyUsed).toBe(14)
-    expect(logic.units.size).toBe(16)
-    expect(logic.eventLog.length).toBe(3)
+    expect(logic.supplyUsed).toBe(12)
+    expect(logic.units.size).toBe(14)
+    expect(logic.eventLog.length).toBe(5)
     expect(logic.errorMessage).toBe("Missing 1 supply to produce 'Drone'.")
 })
 
 test("Add drone during extractor trick", () => {
     const bo: IBuildOrderElement[] = [
+        { name: "Drone", type: "worker" },
+        { name: "Drone", type: "worker" },
         { name: "Drone", type: "worker" },
         { name: "Drone", type: "worker" },
         { name: "Extractor", type: "structure" },
@@ -570,9 +573,9 @@ test("Add drone during extractor trick", () => {
     logic.setStart()
     logic.runUntilEnd()
     expect(logic.supplyLeft).toBe(-1)
-    expect(logic.supplyUsed).toBe(15)
-    expect(logic.units.size).toBe(17)
-    expect(logic.eventLog.length).toBe(4)
+    expect(logic.supplyUsed).toBe(13)
+    expect(logic.units.size).toBe(15)
+    expect(logic.eventLog.length).toBe(6)
 })
 
 test("Production tracking: 3 SupplyDepots and 1 SCV", () => {
@@ -582,6 +585,8 @@ test("Production tracking: 3 SupplyDepots and 1 SCV", () => {
     //   - 2 Supply Depots are still in production (the 2nd and 3rd, still being built by workers)
     //   - 1 SCV is in production (just queued at the CommandCenter)
     const bo: IBuildOrderElement[] = [
+        { name: "SCV", type: "worker" },
+        { name: "SCV", type: "worker" },
         { name: "SupplyDepot", type: "structure" },
         { name: "SupplyDepot", type: "structure" },
         { name: "SupplyDepot", type: "structure" },
@@ -593,7 +598,7 @@ test("Production tracking: 3 SupplyDepots and 1 SCV", () => {
 
     // unitsCountArray has bo.length + 1 snapshots (index 0 = initial state from setStart)
     // Indices 1-4 correspond to each BO item being processed
-    expect(logic.unitsCountArray.length).toBe(5)
+    expect(logic.unitsCountArray.length).toBe(7)
 
     // The snapshot at index 4 is taken when the SCV (4th item) is queued.
     // By this time, the first SupplyDepot (build time = 30s * 16 = 480 frames)

--- a/src/game_logic/gamelogic.ts
+++ b/src/game_logic/gamelogic.ts
@@ -80,9 +80,9 @@ class GameLogic {
         this.boIndex = 0
         this.minerals = 50
         this.vespene = 0
-        this.supplyUsed = 12
-        this.supplyLeft = this.race === "zerg" ? 2 : 3
-        this.supplyCap = this.race === "zerg" ? 14 : 15
+        this.supplyUsed = 8
+        this.supplyLeft = this.race === "zerg" ? 4 : 5
+        this.supplyCap = this.race === "zerg" ? 12 : 13
         this.raceSpecificResource = this.race === "protoss" ? 1 : this.race === "terran" ? 0 : 3
         this.resourceHistory = {
             minerals: [this.minerals],
@@ -96,7 +96,7 @@ class GameLogic {
         this.idleUnits = new Set()
         // Units that have a task, a barracks with reactor that only trains one marine will be busy
         this.busyUnits = new Set()
-        this.workersMinerals = 12
+        this.workersMinerals = 8
         this.workersVespene = 0
         this.workersScouting = 0
         this.muleCount = 0
@@ -156,9 +156,9 @@ class GameLogic {
         this.boIndex = 0
         this.minerals = 50
         this.vespene = 0
-        this.supplyUsed = 12
-        this.supplyLeft = this.race === "zerg" ? 2 : 3
-        this.supplyCap = this.race === "zerg" ? 14 : 15
+        this.supplyUsed = 8
+        this.supplyLeft = this.race === "zerg" ? 4 : 5
+        this.supplyCap = this.race === "zerg" ? 12 : 13
         this.raceSpecificResource = this.race === "protoss" ? 1 : this.race === "terran" ? 0 : 3
         this.resourceHistory = {
             minerals: [this.minerals],
@@ -256,7 +256,7 @@ class GameLogic {
         }
         this.units.add(townhall)
         this.idleUnits.add(townhall)
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < 8; i++) {
             const unit = new Unit(workerName)
             // Add worker delay of 2 seconds before they start gathering minerals
             const workerStartDelayTask = new Task(22.4 * +this.settings.workerStartDelay, this.frame, this.supplyUsed)

--- a/src/game_logic/gamelogic.ts
+++ b/src/game_logic/gamelogic.ts
@@ -734,7 +734,12 @@ class GameLogic {
                 }
             }
 
-            if (trainerUnit.name === "WarpGate") {
+            if (trainerUnit.name === "Gateway" && this.upgrades.has("WarpGateResearch")) {
+                // Training through gateway when warpgate is researched reduces train time
+                // TODO: According to patch notes: speeds up by 35% but the calculations don't match
+                newTask.totalFramesRequired = this.gatewayBuildTimeAfterWarpgateResearch(unit.name)
+                trainerUnit.addTask(this, newTask, trainerCanTrainThroughReactor, true)
+            } else if (trainerUnit.name === "WarpGate") {
                 // Training through warpgate reduces train time to 4 seconds
                 newTask.totalFramesRequired = 3.6 * 22.4
                 trainerUnit.addTask(this, newTask, trainerCanTrainThroughReactor, true)
@@ -995,16 +1000,32 @@ class GameLogic {
     }
 
     /**
+     * Since patch 5.0.16 gateways build faster after warpgate has been researched
+     */
+    gatewayBuildTimeAfterWarpgateResearch(unitName: string): number {
+        const newBuildTime: { [name: string]: number } = {
+            // Values from https://news.blizzard.com/en-us/article/24259080/starcraft-ii-5-0-16-patch-notes
+            Zealot: 16 * 22.4,
+            Adept: 18 * 22.4,
+            Stalker: 18 * 22.4,
+            Sentry: 14 * 22.4,
+            DarkTemplar: 26 * 22.4,
+            HighTemplar: 26 * 22.4,
+        }
+        return newBuildTime[unitName]
+    }
+
+    /**
      * Recover time of warp gates when creating a specific unit, how long the warp gate will be on cooldown after warping in a specific unit
      */
     warpgateRecoverTime(unitName: string): number {
         const recoverTimes: { [name: string]: number } = {
-            Zealot: 20 * 22.4,
-            Adept: 20 * 22.4,
-            Stalker: 23 * 22.4,
-            Sentry: 23 * 22.4,
-            DarkTemplar: 32 * 22.4,
-            HighTemplar: 32 * 22.4,
+            Zealot: 22 * 22.4,
+            Adept: 22 * 22.4,
+            Stalker: 22 * 22.4,
+            Sentry: 22 * 22.4,
+            DarkTemplar: 35 * 22.4,
+            HighTemplar: 35 * 22.4,
         }
         return recoverTimes[unitName]
     }

--- a/src/game_logic/optimize.test.ts
+++ b/src/game_logic/optimize.test.ts
@@ -20,9 +20,9 @@ test("Optimize workers", async () => {
     expect(state !== undefined).toBe(true)
     expect(state?.gamelogic !== undefined).toBe(true)
     if (state?.gamelogic !== undefined) {
-        expect(state.gamelogic.units.size).toBe(25)
+        expect(state.gamelogic.units.size).toBe(21)
         expect(state.gamelogic.eventLog.length).toBe(15)
-        expect(state.gamelogic.supplyCap).toBe(22)
+        expect(state.gamelogic.supplyCap).toBe(20)
     }
 })
 
@@ -45,9 +45,9 @@ test("Optimize nexus chronos", async () => {
     expect(state !== undefined).toBe(true)
     expect(state?.gamelogic !== undefined).toBe(true)
     if (state?.gamelogic !== undefined) {
-        expect(state.gamelogic.units.size).toBe(19)
+        expect(state.gamelogic.units.size).toBe(15)
         expect(state.gamelogic.eventLog.length).toBe(8)
-        expect(state.gamelogic.supplyCap).toBe(23)
+        expect(state.gamelogic.supplyCap).toBe(21)
     }
 })
 
@@ -71,9 +71,9 @@ test("Optimize MULEs", async () => {
     expect(state !== undefined).toBe(true)
     expect(state?.gamelogic !== undefined).toBe(true)
     if (state?.gamelogic !== undefined) {
-        expect(state.gamelogic.units.size).toBe(19)
+        expect(state.gamelogic.units.size).toBe(15)
         expect(state.gamelogic.eventLog.length).toBe(9)
-        expect(state.gamelogic.supplyCap).toBe(23)
+        expect(state.gamelogic.supplyCap).toBe(21)
     }
 })
 
@@ -97,8 +97,8 @@ test("Optimize injects", async () => {
     expect(state !== undefined).toBe(true)
     expect(state?.gamelogic !== undefined).toBe(true)
     if (state?.gamelogic !== undefined) {
-        expect(state.gamelogic.units.size).toBe(16)
+        expect(state.gamelogic.units.size).toBe(12)
         expect(state.gamelogic.eventLog.length).toBe(13)
-        expect(state.gamelogic.supplyCap).toBe(20)
+        expect(state.gamelogic.supplyCap).toBe(18)
     }
 })

--- a/src/game_logic/unit.ts
+++ b/src/game_logic/unit.ts
@@ -147,8 +147,9 @@ class Unit {
         if (["Hatchery", "Lair", "Hive"].includes(this.name)) {
             // Larva naturally spawns every 15 seconds at normal speed
             // Faster speed is a 1.4 multiplier, so the spawn timer at faster is
-            // 15 / 1.4 = 10.71428571...
-            const larvaSpawnTime = 10.71428571
+            // Used to be: 15 / 1.4 = 10.71428571...
+            // Changed in 5.0.16: https://news.blizzard.com/en-us/article/24259080/starcraft-ii-5-0-16-patch-notes
+            const larvaSpawnTime = 9.5
 
             //init larva time for new hatch
             if (this.nextLarvaSpawn === -1) {


### PR DESCRIPTION
- Update balance patch data (hatchery back to 300 minerals cost)
- Change starting workers to 8
- Change starting supply cap
- Change larva timer
- Add 25/25 cost to morph gateways to warpgates
- Gateways produce faster after warpgate upgrade has been researched